### PR TITLE
Remove explicit region assigning

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ val conf = new SparkConf()
   .set("spark.cassandra.connection.host", "node-1.mycluster.example.com")
   .set("spark.cassandra.auth.username", "rickastley")
   .set("spark.cassandra.auth.password", "nevergonnagiveyouup")
-  .set("spark.cassandra.connection.factory", "co.verdigris.spark.connector.cql.AwsS3USEast1ConnectionFactory")
+  .set("spark.executorEnv.AWS_REGION", "us-east-1")
+  .set("spark.cassandra.connection.factory", "co.verdigris.spark.connector.cql.S3ConnectionFactory")
   .set("spark.cassandra.connection.ssl.enabled", "true")
   .set("spark.cassandra.connection.ssl.trustStore.path", "s3://my-tls-bucket/my-cluster.jks")
   .set("spark.cassandra.connection.ssl.trustStore.password", "nevergonnaletyoudown")
@@ -114,7 +115,8 @@ val cluster1 = CassandraConnector(sc.getConf
     .set("spark.cassandra.connection.host", "node-1.mycluster.example.com")
     .set("spark.cassandra.auth.username", "rickastley")
     .set("spark.cassandra.auth.password", "nevergonnagiveyouup")
-    .set("spark.cassandra.connection.factory", "co.verdigris.spark.connector.cql.AwsS3USEast1ConnectionFactory")
+    .set("spark.executorEnv.AWS_REGION", "us-east-1")
+    .set("spark.cassandra.connection.factory", "co.verdigris.spark.connector.cql.S3ConnectionFactory")
     .set("spark.cassandra.connection.ssl.enabled", "true")
     .set("spark.cassandra.connection.ssl.trustStore.path", "s3://my-tls-bucket/my-cluster.jks")
     .set("spark.cassandra.connection.ssl.trustStore.password", "nevergonnaletyoudown"))
@@ -123,7 +125,8 @@ val cluster2 = CassandraConnector(sc.getConf
     .set("spark.cassandra.connection.host", "node-1.othercluster.example.com")
     .set("spark.cassandra.auth.username", "rickastley")
     .set("spark.cassandra.auth.password", "nevergonnagiveyouup")
-    .set("spark.cassandra.connection.factory", "co.verdigris.spark.connector.cql.AwsS3USEast1ConnectionFactory")
+    .set("spark.executorEnv.AWS_REGION", "us-east-1")
+    .set("spark.cassandra.connection.factory", "co.verdigris.spark.connector.cql.S3ConnectionFactory")
     .set("spark.cassandra.connection.ssl.enabled", "true")
     .set("spark.cassandra.connection.ssl.trustStore.path", "s3://my-tls-bucket/other-cluster.jks")
     .set("spark.cassandra.connection.ssl.trustStore.password", "nevergonnatellalie"))
@@ -144,31 +147,6 @@ val lyricsRdd = {
 }
 ```
 
-### Connection factories by S3 regions
-
-Use appropriate connection factory class depending on the region your S3 bucket
-is located in.
-
-All classes below are available under `co.verdigris.spark.connector.cql`
-package.
-
-| Region Name               |    Region ▴    | Factory                              |
-| :------------------------ | :------------: | :----------------------------------- |
-| Asia Pacific (Tokyo)      | ap-northeast-1 | `AwsS3APNortheast1ConnectionFactory` |
-| Asia Pacific (Seoul)      | ap-northeast-2 | `AwsS3APNortheast2ConnectionFactory` |
-| Asia Pacific (Mumbai)     | ap-south-1     | `AwsS3APSouth1ConnectionFactory`     |
-| Asia Pacific (Singapore)  | ap-southeast-1 | `AwsS3APSoutheast1ConnectionFactory` |
-| Asia Pacific (Sydney)     | ap-southeast-2 | `AwsS3APSoutheast2ConnectionFactory` |
-| Canada (Central)          | ca-central-1   | `AwsS3CACentral1ConnectionFactory`   |
-| EU (Frankfurt)            | eu-central-1   | `AwsS3EUCentral1ConnectionFactory`   |
-| EU (Ireland)              | eu-west-1      | `AwsS3EUWest1ConnectionFactory`      |
-| EU (London)               | eu-west-2      | `AwsS3EUWest2ConnectionFactory`      |
-| South America (São Paulo) | sa-east-1      | `AwsS3SAEast1ConnectionFactory`      |
-| US East (N. Virginia)     | us-east-1      | `AwsS3USEast1ConnectionFactory`      |
-| US East (Ohio)            | us-east-2      | `AwsS3USEast2ConnectionFactory`      |
-| US West (N. California)   | us-west-1      | `AwsS3USWest1ConnectionFactory`      |
-| US West (Oregon)          | us-west-2      | `AwsS3USWest2ConnectionFactory`      |
-
 ## Known Issues
 
 ### Missing support for client auth
@@ -185,7 +163,8 @@ issue that may or may not eventually be worked on. For now, the library cannot
 be used to do per-cluster Dataset/DataFrame configuration such as the following:
 
 ```scala
-sqlContext.setConf("MyCluster1/spark.cassandra.connection.factory", "co.verdigris.spark.connector.cql.AwsS3USEast1ConnectionFactory")
+sqlContext.setConf("MyCluster1/spark.executorEnv.AWS_REGION", "us-east-1")
+sqlContext.setConf("MyCluster1/spark.cassandra.connection.factory", "co.verdigris.spark.connector.cql.S3ConnectionFactory")
 sqlContext.setConf("MyCluster2/spark.cassandra.connection.factory", "DefaultConnectionFactory")
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.amazonaws.services.s3.model.Region
 
 name := "spark-cassandra-connection-factory"
 organization := "co.verdigris.spark"
-version := "0.3.5"
+version := "0.4.0"
 scalaVersion := "2.11.10"
 crossScalaVersions := Seq("2.10.6", "2.11.10")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
+resolvers += Resolver.jcenterRepo
 
-addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.15.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.19.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APNortheast1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APNortheast1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3APNortheast1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.AP_NORTHEAST_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APNortheast2ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APNortheast2ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3APNortheast2ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.AP_NORTHEAST_2.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APSouth1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APSouth1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3APSouth1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.AP_SOUTH_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APSoutheast1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APSoutheast1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3APSoutheast1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.AP_SOUTHEAST_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APSoutheast2ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3APSoutheast2ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3APSoutheast2ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.AP_SOUTHEAST_2.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3CACentral1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3CACentral1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3CACentral1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.CA_CENTRAL_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3CNNorth1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3CNNorth1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3CNNorth1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.CN_NORTH_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3EUCentral1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3EUCentral1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3EUCentral1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.EU_CENTRAL_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3EUWest1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3EUWest1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3EUWest1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.EU_WEST_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3EUWest2ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3EUWest2ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3EUWest2ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.EU_WEST_2.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3GovCloudConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3GovCloudConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3GovCloudConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.GovCloud.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3SAEast1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3SAEast1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3SAEast1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.SA_EAST_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3USEast1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3USEast1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3USEast1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.US_EAST_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3USEast2ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3USEast2ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3USEast2ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.US_EAST_2.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3USWest1ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3USWest1ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3USWest1ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.US_WEST_1.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/AwsS3USWest2ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/AwsS3USWest2ConnectionFactory.scala
@@ -2,6 +2,6 @@ package co.verdigris.spark.connector.cql
 
 import com.amazonaws.regions.Regions
 
+@deprecated("Use co.verdigris.spark.connector.cql.S3ConnectionFactory with spark.executorEnv.AWS_REGION instead", "0.4.0")
 object AwsS3USWest2ConnectionFactory extends S3ConnectionFactory {
-  this.s3Region = Some(Regions.US_WEST_2.getName)
 }

--- a/src/main/scala/co/verdigris/spark/connector/cql/S3ConnectionFactory.scala
+++ b/src/main/scala/co/verdigris/spark/connector/cql/S3ConnectionFactory.scala
@@ -5,12 +5,8 @@ import com.datastax.driver.core.policies.ExponentialReconnectionPolicy
 import com.datastax.driver.core.{Cluster, QueryOptions, SSLOptions, SocketOptions}
 import com.datastax.spark.connector.cql.CassandraConnectorConf.CassandraSSLConf
 import com.datastax.spark.connector.cql._
-import org.apache.spark.{SparkConf, SparkContext}
 
-trait S3ConnectionFactory extends CassandraConnectionFactory {
-  protected val sparkConf: SparkConf = SparkContext.getOrCreate().getConf
-  protected var s3Region: Option[String] = sparkConf.getOption("spark.connection.ssl.s3AwsRegion")
-
+class S3ConnectionFactory extends CassandraConnectionFactory {
   /** Returns the Cluster.Builder object used to setup Cluster instance. */
   def clusterBuilder(conf: CassandraConnectorConf): Cluster.Builder = {
     val options = new SocketOptions()
@@ -50,7 +46,6 @@ trait S3ConnectionFactory extends CassandraConnectionFactory {
       Some(
         AwsS3SSLOptions.builder()
           .withSSLConf(conf)
-          .withAwsRegion(this.s3Region)
           .build()
       )
     } else {
@@ -60,3 +55,5 @@ trait S3ConnectionFactory extends CassandraConnectionFactory {
 
   override def createCluster(conf: CassandraConnectorConf): Cluster = clusterBuilder(conf).build()
 }
+
+object S3ConnectionFactory extends S3ConnectionFactory

--- a/src/test/scala/co/verdigris/spark/connector/cql/S3ConnectionFactoryTest.scala
+++ b/src/test/scala/co/verdigris/spark/connector/cql/S3ConnectionFactoryTest.scala
@@ -1,0 +1,23 @@
+package co.verdigris.spark.connector.cql
+
+import com.datastax.driver.core.Cluster
+
+class S3ConnectionFactoryTest extends ConnectionFactorySpec {
+  override def beforeAll {
+    super.beforeAll
+
+    factory = S3ConnectionFactory
+  }
+
+  describe(".clusterBuilder") {
+    it("should return a new Cluster.Builder instance") {
+      factory.clusterBuilder(cassandraConf) shouldBe a [Cluster.Builder]
+    }
+  }
+
+  describe(".createCluster") {
+    it("should return a new Cluster instance") {
+      factory.createCluster(cassandraConf) shouldBe a [Cluster]
+    }
+  }
+}


### PR DESCRIPTION
SparkConf is intended for passing configuration to
driver, and driver would not pass those configuration
to executors. Thus, using this factory in a multi
node spark cluster would result in error.

User must set AWS region through environment variable
AWS_REGION.